### PR TITLE
Fix deprecated pytest imports

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -12,6 +12,20 @@ hide:
 
 [//]: # (--------------------------------------------------------------------------------------------------------------)
 
+## [v0.1.3](https://github.com/dapensoft/pyorlib/releases/tag/0.1.3) <small>July 30, 2025</small> { id="0.1.3" }
+
+<hr class="divider">
+
+##### Changed
+
+- Updated the lower bound variable definition in `pulp_engine` to set it to `None` when `-inf` is specified as the lower bound.
+
+##### Fixed
+
+- Updated deprecated `_pytest.python_api.raises` imports in several tests.
+
+[//]: # (--------------------------------------------------------------------------------------------------------------)
+
 ## [v0.1.2](https://github.com/dapensoft/pyorlib/releases/tag/0.1.2) <small>April 9, 2024</small> { id="0.1.2" }
 
 <hr class="divider">

--- a/src/pyorlib/__init__.py
+++ b/src/pyorlib/__init__.py
@@ -3,7 +3,7 @@ A powerful Python library for operations research. Define, solve, and interact w
 mathematical models in a standardized manner across different optimization packages.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 from .engines import Engine
 from .model import Model

--- a/src/pyorlib/engines/pulp/pulp_engine.py
+++ b/src/pyorlib/engines/pulp/pulp_engine.py
@@ -100,14 +100,14 @@ class PuLPEngine(Engine):
                 pulp_var = LpVariable(
                     name=name,
                     cat=LpInteger,
-                    lowBound=lower_bound,
+                    lowBound=lower_bound if lower_bound > -inf else None,
                     upBound=upper_bound if upper_bound < inf else None,
                 )
             elif self.value_type == ValueType.CONTINUOUS:
                 pulp_var = LpVariable(
                     name=name,
                     cat=LpContinuous,
-                    lowBound=lower_bound,
+                    lowBound=lower_bound if lower_bound > -inf else None,
                     upBound=upper_bound if upper_bound < inf else None,
                 )
             else:

--- a/tests/algebra/expressions/test_expression.py
+++ b/tests/algebra/expressions/test_expression.py
@@ -1,6 +1,6 @@
 from math import isclose
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.algebra import Element, Expression
 

--- a/tests/algebra/terms/constants/test_constant.py
+++ b/tests/algebra/terms/constants/test_constant.py
@@ -1,6 +1,6 @@
 from math import inf
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.algebra import Term, Constant
 from pyorlib.enums import ValueType, TermType

--- a/tests/algebra/terms/test_term.py
+++ b/tests/algebra/terms/test_term.py
@@ -1,7 +1,7 @@
 from math import isclose
 from typing import Any
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.algebra import Element, Expression, Term, Constant
 from pyorlib.enums import ValueType

--- a/tests/algebra/terms/variables/test_variable.py
+++ b/tests/algebra/terms/variables/test_variable.py
@@ -1,6 +1,6 @@
 from math import inf
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.algebra import Term, Variable
 from pyorlib.engines import Engine

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,7 +1,7 @@
 from math import inf
 from typing import List
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib import Model, Engine
 from pyorlib.algebra import Term, Element

--- a/tests/structures/parameters/test_multi_value_parameter.py
+++ b/tests/structures/parameters/test_multi_value_parameter.py
@@ -1,6 +1,6 @@
 from math import inf
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.enums import ParameterType, ValueType
 from pyorlib.structures import MultiValueParameter, Parameter

--- a/tests/structures/parameters/test_single_value_parameter.py
+++ b/tests/structures/parameters/test_single_value_parameter.py
@@ -1,6 +1,6 @@
 from math import inf
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.enums import ParameterType, ValueType
 from pyorlib.structures import SingleValueParameter, Parameter

--- a/tests/validators/fields/test_dimension_field.py
+++ b/tests/validators/fields/test_dimension_field.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.validators import DimensionField
 

--- a/tests/validators/fields/test_parameter_field.py
+++ b/tests/validators/fields/test_parameter_field.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from _pytest.python_api import raises
+from pytest import raises
 
 from pyorlib.enums import ParameterType, ValueType
 from pyorlib.structures import SingleValueParameter, MultiValueParameter


### PR DESCRIPTION
## Initial Checks

- [X] The code compiles successfully without any errors or warnings.
- [X] I have personally tested these changes on my local environment.
- [X] I have ensured that relevant documentation has been added or updated.
- [X] I adhere to the project structure and code standards defined in the documentation.
- [X] My code follows the established coding style guidelines.
- [X] I have added tests for the new code (if applicable).
- [X] All existing tests have passed successfully.

## Description

This pull request fixes deprecated imports on some tests were pytest.raises is used.